### PR TITLE
Caractéristique : réduction de moitié des récompenses en gemmes et en or pour les niveaux d'histoire après la première complétion

### DIFF
--- a/script.js
+++ b/script.js
@@ -2553,10 +2553,20 @@
                 let isRewardReduced = false;
                 const affectedTypesForReduction = ['legendary', 'challenge', 'material'];
 
-                if (affectedTypesForReduction.includes(levelData.type) && progress.completed) {
+                // Réduction pour les niveaux histoire déjà complétés
+                if (levelData.type === 'story' && !levelData.isInfinite && progress.completed) {
+                    actualGemsToAward = Math.floor(baseGemsRewardForLevel * 0.5);
+                    actualCoinsToAward = Math.floor(baseCoinsRewardForLevel * 0.5);
+                    // L'EXP n'est pas réduite pour les niveaux histoire répétées selon la demande initiale implicite.
+                    // Si l'EXP doit aussi être réduite pour les niveaux histoire, ajoutez:
+                    // actualExpToAward = Math.floor(baseExpRewardForLevel * 0.5);
+                    isRewardReduced = true; // Marquer qu'une réduction a eu lieu (utile pour l'affichage du message)
+                }
+                // Réduction pour les autres types de niveaux déjà complétés
+                else if (affectedTypesForReduction.includes(levelData.type) && progress.completed) {
                     actualGemsToAward = Math.floor(baseGemsRewardForLevel * 0.5);
                     actualExpToAward = Math.floor(baseExpRewardForLevel * 0.5);
-                    // actualCoinsToAward = Math.floor(baseCoinsRewardForLevel * 0.5); // Décommentez si les pièces doivent aussi être réduites
+                    // actualCoinsToAward = Math.floor(baseCoinsRewardForLevel * 0.5); // Les pièces ne sont pas réduites pour ces types actuellement
                     isRewardReduced = true;
                 }
 
@@ -2594,18 +2604,25 @@
                 selectedCharsObjects.forEach(char => addCharacterExp(char, actualExpToAward)); // De même pour l'EXP des personnages
 
                 let rewardMessageParts = [];
+                // Gems
                 rewardMessageParts.push(`+${finalGemsAwarded} gemmes`);
-                if (isRewardReduced && affectedTypesForReduction.includes(levelData.type)) {
+                if (isRewardReduced && (levelData.type === 'story' || affectedTypesForReduction.includes(levelData.type))) {
                     rewardMessageParts.push('(réduit)');
                 }
                 if (fortuneBonusGems > 0) rewardMessageParts.push(`(+${fortuneBonusGems} Fortune)`);
                 if (golderBonusGems > 0) rewardMessageParts.push(`(+${golderBonusGems} Golder)`);
                 
+                // Coins
                 rewardMessageParts.push(`, +${finalCoinsAwarded} pièces`);
+                if (isRewardReduced && levelData.type === 'story') { // Reduction de pièces s'applique seulement aux niveaux histoire pour l'instant
+                    rewardMessageParts.push('(réduit)');
+                }
                 if (golderBonusCoins > 0) rewardMessageParts.push(`(+${golderBonusCoins} Golder)`);
 
+                // EXP
                 rewardMessageParts.push(`, +${actualExpToAward} EXP`);
-                 if (isRewardReduced && affectedTypesForReduction.includes(levelData.type)) {
+                // La réduction d'EXP pour 'story' n'est pas faite, donc on vérifie seulement affectedTypesForReduction
+                if (isRewardReduced && affectedTypesForReduction.includes(levelData.type)) {
                     rewardMessageParts.push('(réduit)');
                 }
 


### PR DESCRIPTION
Caractéristique : réduction de moitié des récompenses en gemmes et en or pour les niveaux d'histoire après la première complétion

- Modifie le calcul des récompenses dans `script.js` pour réduire les récompenses en gemmes et en pièces de 50% pour les niveaux d'histoire lors des achèvements suivants.
- Mise à jour du message d'issue de combat pour afficher « (réduit) » à côté des quantités de gemmes et de pièces lorsque cette réduction se produit pour les niveaux d'histoire.
- S'assure que la logique de réduction des récompenses et les messages existants pour les autres types de niveaux (légendaire, défi, matériel) sont préservés.