### PR TITLE
fix-crystal-layout

### DIFF
--- a/script.js
+++ b/script.js
@@ -3627,7 +3627,7 @@
         // --- FIN DE L'ANIMATION & NETTOYAGE (Commun aux deux modes) ---
         
         const clickToCloseIndicator = document.createElement('p');
-        clickToCloseIndicator.className = 'absolute bottom-4 sm:bottom-20 text-white text-sm animate-pulse z-50';
+        clickToCloseIndicator.className = 'absolute bottom-4 sm:bottom-20 left-0 right-0 text-center text-white/90 text-lg animate-pulse z-50 drop-shadow-lg';
         clickToCloseIndicator.textContent = 'Cliquez pour continuer';
         summonAnimationModal.appendChild(clickToCloseIndicator);
 

--- a/style.css
+++ b/style.css
@@ -296,6 +296,8 @@ body {
     gap: 1.25rem;
     padding: 1.25rem;
     perspective: 1000px; /* safe */
+    justify-content: center;
+    align-content: center;
 }
 
 /* Wrapper 3D: on flippe UNIQUEMENT le wrapper */
@@ -355,7 +357,8 @@ body {
     overflow: hidden; 
 }
 .summon-grid-card-img {
-    max-height: 75%; /* image perso plus grande */
+    height: 140px;
+    width: auto;
     max-width: 100%;
     object-fit: contain;
     margin-bottom: 4px;


### PR DESCRIPTION
feat: Improve styling of 'Click to continue' text

This commit improves the positioning and style of the 'Click to continue' text that appears at the end of the summon animation.

Based on your feedback, the following changes were made in `script.js`:
- The text is now horizontally centered on the screen using 'left-0 right-0 text-center'.
- The font size has been increased from 'text-sm' to 'text-lg'.
- A drop shadow and slight transparency ('drop-shadow-lg text-white/90') have been added for better readability and a more polished look.